### PR TITLE
update nodejs runtime to 10.x for lambdas

### DIFF
--- a/static-site-hosting/advanced-route53-acm.yml
+++ b/static-site-hosting/advanced-route53-acm.yml
@@ -200,7 +200,7 @@ Resources:
       Handler: 'index.handler'
       MemorySize: 128
       Role: !GetAtt 'LambdaRole.Arn'
-      Runtime: 'nodejs8.10'
+      Runtime: 'nodejs10.x'
       Timeout: 5
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'


### PR DESCRIPTION
14.x is also available but it will throw following error:

"ZipFile can only be used when Runtime is set to......"